### PR TITLE
Expose Clear Function

### DIFF
--- a/src/directive/angular-echarts.directive.ts
+++ b/src/directive/angular-echarts.directive.ts
@@ -181,4 +181,10 @@ export class AngularEchartsDirective implements OnChanges, OnDestroy {
       myChart.on('dataZoom', (e: any) => { this.chartDataZoom.emit(e); });
     }
   }
+
+  public clear()  {
+    if (this.myChart) {
+      this.myChart.clear();
+    }
+  }
 }


### PR DESCRIPTION
I'm reusing the charts for different datasets.
This works fine as long as all data is replaced. Unreplaced datasets will stay in the new chart. 

Clearing the chart resolves this issue for me and could be useful for others as well. 