### PR TITLE
Add resetChart function

### DIFF
--- a/src/directive/angular-echarts.directive.ts
+++ b/src/directive/angular-echarts.directive.ts
@@ -47,6 +47,11 @@ export class AngularEchartsDirective implements OnChanges, OnDestroy {
     this.myChart.resize();
   }
 
+  private resetChart() {
+    this.myChart.setOption({}, true);
+    this.myChart.resize();
+  }
+
   @HostListener('window:resize', ['$event']) onWindowResize(event: any) {
     if (event.target.innerWidth !== this.currentWindowWidth) {
       this.currentWindowWidth = event.target.innerWidth;
@@ -94,6 +99,8 @@ export class AngularEchartsDirective implements OnChanges, OnDestroy {
       } else if (this.dataset && this.dataset.length) {
         this.mergeDataset(this.dataset);
         this.updateChart();
+      } else {
+        this.resetChart();
       }
     }
   }
@@ -176,7 +183,7 @@ export class AngularEchartsDirective implements OnChanges, OnDestroy {
       myChart.on('mouseout', (e: any) => { this.chartMouseOut.emit(e); });
       myChart.on('globalout', (e: any) => { this.chartGlobalOut.emit(e); });
       myChart.on('contextmenu', (e: any) => { this.chartContextMenu.emit(e); });
-      
+
       // other events;
       myChart.on('dataZoom', (e: any) => { this.chartDataZoom.emit(e); });
     }

--- a/src/directive/angular-echarts.directive.ts
+++ b/src/directive/angular-echarts.directive.ts
@@ -49,7 +49,6 @@ export class AngularEchartsDirective implements OnChanges, OnDestroy {
 
   private resetChart() {
     this.myChart.setOption({}, true);
-    this.myChart.resize();
   }
 
   @HostListener('window:resize', ['$event']) onWindowResize(event: any) {
@@ -99,7 +98,7 @@ export class AngularEchartsDirective implements OnChanges, OnDestroy {
       } else if (this.dataset && this.dataset.length) {
         this.mergeDataset(this.dataset);
         this.updateChart();
-      } else {
+      } else if (JSON.stringify(opt) === '{}' && !this.dataset) {
         this.resetChart();
       }
     }


### PR DESCRIPTION
if we update '[options] = {}' run resetChart
- add private resetChart funtion
- fix onOptionsChange

I read this echart github question and change it.
https://github.com/ecomfe/echarts/issues/2387
We can update empty data chart or remove old result chart data.