### PR TITLE
New input to control activation/deactivation of chart auto-resize feature

### DIFF
--- a/lib/src/directive/ngx-echarts.directive.ts
+++ b/lib/src/directive/ngx-echarts.directive.ts
@@ -13,6 +13,7 @@ export class NgxEchartsDirective implements OnChanges, OnDestroy {
   @Input() loading: boolean;
   @Input() initOpts: any;
   @Input() merge: any;
+  @Input() autoResize: boolean = true;
 
   // chart events:
   @Output() chartInit = new EventEmitter<any>();
@@ -47,7 +48,7 @@ export class NgxEchartsDirective implements OnChanges, OnDestroy {
 
   @HostListener('window:resize', ['$event'])
   onWindowResize(event: any) {
-    if (event.target.innerWidth !== this.currentWindowWidth) {
+    if (this.autoResize && event.target.innerWidth !== this.currentWindowWidth) {
       this.currentWindowWidth = event.target.innerWidth;
       if (this._chart) {
         this._chart.resize();


### PR DESCRIPTION
I'm working on an app where the chart auto-resize feature is conflicting with the rendering of other components when toggling from/to fullscreen view. 
I'd like to be  able to control whether or not this auto-resize feature is activated.

I propose to add an 'autoResize' input in NgxEchartsDirective, controlling the activation of the auto-resize feature triggered by a window resize event.
Of course, by default, the automatic resize feature is activated (autoResize = true).