### PR TITLE
feat(usability): added typings and moved the angular cli configuration to the tsconfig.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,28 +61,27 @@ A starter project on Github: https://github.com/xieziyu/ngx-echarts-starter
 # Installation
 ```bash
 # if you use npm
-npm install echarts --save
-npm install ngx-echarts --save
+npm install echarts -S
+npm install @types/echarts -D
+npm install ngx-echarts -S
 
 # or if you use yarn
 yarn add echarts
+yarn add @types/echarts -D
 yarn add ngx-echarts
 ```
 
 ## How to use it within:
-+ `angular-cli`: If you already have an angular-cli project. You need to import echarts in the **"scripts"** list of `angular-cli.json` just like:
++ `angular-cli`: If you already have an angular-cli project. You need to map the echarts path to minified version of echarts in the **compilerOptions** of **"tsconfig.json"** in your project's root (this is important for AOT build):
 
 ```diff
 {
-  // projects ...
-  "architect": {
-    "build": {
-      "options": {
-        "scripts": [
-+         "node_modules/echarts/dist/echarts.min.js"
-        ]
-      }
-    }
+  ...,
+  "compilerOptions": {
+    ...,
++    "paths": {
++      "echarts": ["node_modules/echarts/dist/echarts.min.js"]
++    }
   }
 }
 ```

--- a/angular.json
+++ b/angular.json
@@ -33,9 +33,6 @@
               "node_modules/angular2-draggable/css/resizable.min.css"
             ],
             "scripts": [
-              "node_modules/echarts/dist/echarts.min.js",
-              "node_modules/echarts/dist/extension/bmap.min.js",
-              "node_modules/marked/lib/marked.js",
               "node_modules/prismjs/prism.js",
               "node_modules/prismjs/components/prism-markup.min.js",
               "node_modules/prismjs/components/prism-css.min.js",
@@ -43,9 +40,7 @@
               "node_modules/prismjs/components/prism-javascript.min.js",
               "node_modules/prismjs/components/prism-bash.min.js",
               "node_modules/prismjs/components/prism-diff.min.js",
-              "node_modules/prismjs/components/prism-scss.min.js",
-              "src/theme/dark.js",
-              "src/theme/macarons.js"
+              "node_modules/prismjs/components/prism-scss.min.js"
             ]
           },
           "configurations": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@angular/compiler-cli": "^6.0.0",
     "@angular/language-service": "^6.0.0",
     "@compodoc/compodoc": "^1.1.2",
+    "@types/echarts": "^0.0.13",
     "@types/jasmine": "~2.8.6",
     "@types/jasminewd2": "~2.0.3",
     "@types/node": "~8.9.4",

--- a/projects/ngx-echarts/package.json
+++ b/projects/ngx-echarts/package.json
@@ -4,6 +4,7 @@
   "peerDependencies": {
     "@angular/common": "^6.0.0-rc.0 || ^6.0.0",
     "@angular/core": "^6.0.0-rc.0 || ^6.0.0",
-    "echarts": ">=3.1.1"
+    "echarts": ">=3.1.1",
+    "@types/echarts": "0.0.13"
   }
 }

--- a/projects/ngx-echarts/src/lib/ngx-echarts.service.ts
+++ b/projects/ngx-echarts/src/lib/ngx-echarts.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
-
-declare var echarts: any;
+import * as echarts from 'echarts';
 
 /**
  * Provide an wrapper for global echarts
@@ -30,7 +29,7 @@ export class NgxEchartsService {
   constructor() {}
 
   /**
-   * Get global echarts object
+   * Get echarts object
    */
   get echarts(): any {
     return echarts;
@@ -61,7 +60,7 @@ export class NgxEchartsService {
    * Wrapper for echarts.disconnect
    */
   get disconnect(): any {
-    return this._checkEcharts() ? echarts.disconnect : undefined;
+    return this._checkEcharts() ? (<any>echarts).disconnect : undefined;
   }
 
   /**

--- a/src/app/views/usage/events/events.component.ts
+++ b/src/app/views/usage/events/events.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
+import { graphic } from 'echarts';
 
 declare const require: any;
-declare const echarts: any;
 
 @Component({
   selector: 'app-events',
@@ -79,7 +79,7 @@ export class EventsComponent implements OnInit {
           type: 'bar',
           itemStyle: {
             normal: {
-              color: new echarts.graphic.LinearGradient(
+              color: new graphic.LinearGradient(
                 0, 0, 0, 1,
                 [
                   { offset: 0, color: '#83bff6' },
@@ -89,7 +89,7 @@ export class EventsComponent implements OnInit {
               )
             },
             emphasis: {
-              color: new echarts.graphic.LinearGradient(
+              color: new graphic.LinearGradient(
                 0, 0, 0, 1,
                 [
                   { offset: 0, color: '#2378f7' },

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,15 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
+import * as echarts from 'echarts';
+
+(<any>window).echarts = echarts; // dirty: install global variables for side packages
+
+// ideally needs to be changed to ES6 import
+import './theme/dark.js';
+import './theme/macarons.js';
+import 'echarts/dist/extension/bmap.min.js';
+import 'marked/lib/marked.js';
 
 if (environment.production) {
   enableProdMode();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,9 @@
     "paths": {
       "ngx-echarts": [
         "dist/ngx-echarts"
+      ],
+      "echarts": [
+        "node_modules/echarts/dist/echarts.min.js"
       ]
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -264,6 +264,10 @@
     semver "^5.3.0"
     semver-intersect "^1.1.2"
 
+"@types/echarts@^0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@types/echarts/-/echarts-0.0.13.tgz#e19aed81537c3e68b9ed94300321572e7bed4edd"
+
 "@types/estree@0.0.38":
   version "0.0.38"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.38.tgz#c1be40aa933723c608820a99a373a16d215a1ca2"


### PR DESCRIPTION
a follow-up of #124 

The following is copied from original PR: 

This is definitely not a final pull request, more like a POC.

1. The `main.ts` probably needs to be reworked to use ES6 imports for all the libraries
2. The documentation needs to be updated to not assume to have the global `echarts`
3. Examples should be updated as well
4. Webpack / systemjs setup probably need to be adapted as well
5. Other minor fixes?

Ideas for the future:

1. Deprecate a half of the ngxechartsservice methods as long as the original library's exports could be used instead
2. Other?

The aot build requires minified version in tsconfig paths, see https://github.com/apache/incubator-echarts/issues/8493#issuecomment-401850374