### PR TITLE
Add map events support to echarts directive

### DIFF
--- a/projects/ngx-echarts/src/lib/echart-events.ts
+++ b/projects/ngx-echarts/src/lib/echart-events.ts
@@ -8,6 +8,9 @@ export class EChartEvents {
   static GlobalOut = 'globalout';
   static ContextMenu = 'contextmenu';
   static DataZoom = 'datazoom';
+  static MapSelectChanged = 'mapselectchanged';
+  static MapSelected = 'mapselected';
+  static MapUnselected = 'mapunselected';
 
   static All = [
     EChartEvents.Click,
@@ -19,5 +22,8 @@ export class EChartEvents {
     EChartEvents.GlobalOut,
     EChartEvents.ContextMenu,
     EChartEvents.DataZoom,
+    EChartEvents.MapSelectChanged,
+    EChartEvents.MapSelected,
+    EChartEvents.MapUnselected,
   ];
 }

--- a/projects/ngx-echarts/src/lib/ngx-echarts.directive.ts
+++ b/projects/ngx-echarts/src/lib/ngx-echarts.directive.ts
@@ -43,6 +43,9 @@ export class NgxEchartsDirective implements OnChanges, OnDestroy, DoCheck, After
   @Output() chartGlobalOut = new EventEmitter<any>();
   @Output() chartContextMenu = new EventEmitter<any>();
   @Output() chartDataZoom = new EventEmitter<any>();
+  @Output() chartMapSelectChanged = new EventEmitter<any>();
+  @Output() chartMapSelected = new EventEmitter<any>();
+  @Output() chartMapUnselected = new EventEmitter<any>();
 
   private _chart: ECharts;
   private currentOffsetWidth = 0;
@@ -219,6 +222,15 @@ export class NgxEchartsDirective implements OnChanges, OnDestroy, DoCheck, After
         break;
       case EChartEvents.DataZoom:
         this._ngZone.run(() => this.chartDataZoom.emit(event));
+        break;
+      case EChartEvents.MapSelectChanged:
+        this._ngZone.run(() => this.chartMapSelectChanged.emit(event));
+        break;
+      case EChartEvents.MapSelected:
+        this._ngZone.run(() => this.chartMapSelected.emit(event));
+        break;
+      case EChartEvents.MapUnselected:
+        this._ngZone.run(() => this.chartMapUnselected.emit(event));
         break;
     }
   }


### PR DESCRIPTION
In order to work with these events, the chart map series 'selectedMode' must be set to either 'single' or 'multiple'.