### PR TITLE
Add MIT license to 'ngx-echarts-demo'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "ngx-echarts-demo",
   "version": "4.0.0",
+  "license": "MIT",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --port=4202",


### PR DESCRIPTION
The base package lacks a license. A MIT license helps automated software
auditing.

Close the PR if not applicable.