### PR TITLE
Revert "fix 'init is not defined' error when using rollup complie."

### DIFF
--- a/projects/ngx-echarts/src/lib/ngx-echarts.directive.ts
+++ b/projects/ngx-echarts/src/lib/ngx-echarts.directive.ts
@@ -1,6 +1,5 @@
 import { AfterViewInit, Directive, DoCheck, ElementRef, EventEmitter, Input, NgZone, OnChanges, OnDestroy, OnInit, Output, SimpleChanges } from '@angular/core';
-import { EChartOption, ECharts } from 'echarts';
-import { init } from 'echarts/lib/echarts';
+import { EChartOption, ECharts, init } from 'echarts';
 import { fromEvent, Observable, Subscription } from 'rxjs';
 import { debounceTime, switchMap } from 'rxjs/operators';
 import { ChangeFilter } from './change-filter';


### PR DESCRIPTION
Reverts xieziyu/ngx-echarts#190