### PR TITLE
Added output 'optionsError'

### DIFF
--- a/projects/ngx-echarts/src/lib/ngx-echarts.directive.ts
+++ b/projects/ngx-echarts/src/lib/ngx-echarts.directive.ts
@@ -44,6 +44,7 @@ export class NgxEchartsDirective implements OnChanges, OnDestroy, OnInit, DoChec
 
   // ngx-echarts events
   @Output() chartInit = new EventEmitter<any>();
+  @Output() optionsError = new EventEmitter<Error>();
 
   // echarts mouse events
   @Output() chartClick = this.createLazyEvent('click');
@@ -166,7 +167,13 @@ export class NgxEchartsDirective implements OnChanges, OnDestroy, OnInit, DoChec
 
   private setOption(option: any, opts?: any) {
     if (this.chart) {
-      this.chart.setOption(option, opts);
+      try {
+        this.chart.setOption(option, opts);
+      }
+      catch (e){
+        console.error(e);
+        this.optionsError.emit(e);
+      }
     }
   }
 
@@ -206,7 +213,7 @@ export class NgxEchartsDirective implements OnChanges, OnDestroy, OnInit, DoChec
         this.chartInit.emit(this.chart);
       }
 
-      this.chart.setOption(this.options, true);
+      this.setOption(this.options, true);
     }
   }
 


### PR DESCRIPTION
Added output 'optionsError' to give control over error handling in .setOption(). This could be beneficial especially when options are set dynamically in application. It gives opportunity to inform with custom error about incorrect options or to somehow change options dynamically again.

Simple usage example:
HTML: 
```html
<div echarts [options]="chartOption" (optionsError)="onOptionsError($event)"></div>
```

TS:
```typescript
  chartOption: EChartOption = {
    xAxis: {
      type: 'category',
      data: ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
    },
    series: [
      {
        data: [820, 932, 901, 934, 1290, 1330, 1320],
        type: 'line',
      },
    ],
  };

  onOptionsError(error){
    console.log('do something'); // We will get error because no yAxis is specified
  }
```