### PR TITLE
Add output for brushEnd event

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ It supports following event outputs:
 | chartFocusNodeAdjacency   | echarts event: `'focusnodeadjacency'`   |
 | chartUnfocusNodeAdjacency | echarts event: `'unfocusnodeadjacency'` |
 | chartBrush                | echarts event: `'brush'`                |
+| chartBrushEnd             | echarts event: `'brushend'`             |
 | chartBrushSelected        | echarts event: `'brushselected'`        |
 | chartRendered             | echarts event: `'rendered'`             |
 | chartFinished             | echarts event: `'finished'`             |

--- a/projects/ngx-echarts/src/lib/ngx-echarts.directive.ts
+++ b/projects/ngx-echarts/src/lib/ngx-echarts.directive.ts
@@ -78,6 +78,7 @@ export class NgxEchartsDirective implements OnChanges, OnDestroy, OnInit, DoChec
   @Output() chartFocusNodeAdjacency = this.createLazyEvent('focusnodeadjacency');
   @Output() chartUnfocusNodeAdjacency = this.createLazyEvent('unfocusnodeadjacency');
   @Output() chartBrush = this.createLazyEvent('brush');
+  @Output() chartBrushEnd = this.createLazyEvent('brushend');
   @Output() chartBrushSelected = this.createLazyEvent('brushselected');
   @Output() chartRendered = this.createLazyEvent('rendered');
   @Output() chartFinished = this.createLazyEvent('finished');


### PR DESCRIPTION
Add support for [brushEnd](https://echarts.apache.org/en/api.html#events.brushEnd) event introduced in echarts v4.5.0