### PR TITLE
Export NGX_ECHARTS_CONFIG

### DIFF
--- a/projects/ngx-echarts/src/lib/ngx-echarts.module.ts
+++ b/projects/ngx-echarts/src/lib/ngx-echarts.module.ts
@@ -20,4 +20,4 @@ export class NgxEchartsModule {
   }
 }
 
-export { NgxEchartsDirective };
+export { NgxEchartsDirective, NGX_ECHARTS_CONFIG };


### PR DESCRIPTION
我这里希望能以 shared.module.ts 的方式安装。
写出来大致是这个样子

```ts
import { NgxEchartsModule, NGX_ECHARTS_CONFIG } from 'ngx-echarts';
import * as echarts from 'echarts'; 


@NgModule({
  imports: [
    NgxEchartsModule,
  ],
  exports: [
    NgxEchartsModule,
  ],
  providers: [
    { provide: NGX_ECHARTS_CONFIG, useValue: echarts },
  ],
})
export class SharedModule { }
```

能麻烦把这个选项 export 出来么？