### PR TITLE
Fix Angular 10 generic ModuleWithProviders depreciation

### DIFF
--- a/projects/ngx-echarts/src/lib/ngx-echarts.module.ts
+++ b/projects/ngx-echarts/src/lib/ngx-echarts.module.ts
@@ -7,7 +7,7 @@ import { NgxEchartsDirective, NgxEchartsConfig, NGX_ECHARTS_CONFIG } from './ngx
   exports: [NgxEchartsDirective],
 })
 export class NgxEchartsModule {
-  static forRoot(config: NgxEchartsConfig): ModuleWithProviders {
+  static forRoot(config: NgxEchartsConfig): ModuleWithProviders<NgxEchartsModule> {
     return {
       ngModule: NgxEchartsModule,
       providers: [{ provide: NGX_ECHARTS_CONFIG, useValue: config }],


### PR DESCRIPTION
Not tested but should resolve https://github.com/xieziyu/ngx-echarts/issues/250
See this for more info https://angular.io/guide/migration-module-with-providers