### PR TITLE
Guard dispose

### DIFF
--- a/projects/ngx-echarts/src/lib/ngx-echarts.directive.ts
+++ b/projects/ngx-echarts/src/lib/ngx-echarts.directive.ts
@@ -222,7 +222,13 @@ export class NgxEchartsDirective implements OnChanges, OnDestroy, OnInit, AfterV
         (chart: any) =>
           new Observable((observer) => {
             chart.on(eventName, (data: T) => this.ngZone.run(() => observer.next(data)));
-            return () => chart.off(eventName);
+            return () => {
+              if (this.chart) {
+                if (!this.chart.isDisposed()) {
+                  chart.off(eventName);
+                }
+              }
+            }
           }),
       ),
     ) as EventEmitter<T>;


### PR DESCRIPTION
This prevents multiple attempts to dispose a chart if it already has been disposed. This will prevent the display of Echarts warning message.