### PR TITLE
Add missing resize-observer steps in welcome bash installation code

### DIFF
--- a/src/app/pages/welcome/welcome.component.html
+++ b/src/app/pages/welcome/welcome.component.html
@@ -31,10 +31,12 @@
         # if you use npm
         npm install echarts -S
         npm install ngx-echarts -S
+        npm install @juggle/resize-observer -S
 
         # or if you use yarn
         yarn add echarts
         yarn add ngx-echarts
+        yarn add -D @juggle/resize-observer
         ```
       </markdown>
     </div>


### PR DESCRIPTION
As I mentioned here: https://github.com/xieziyu/ngx-echarts/issues/314

The welcome page seems to be missing installation steps