### PR TITLE
Add initOpts locale property and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,13 @@ A starter project on Github: https://github.com/xieziyu/ngx-echarts-starter
 # Latest Update
 
 - 2021.05.17: v7.0.0:
+
   - Feat: support Angular v11, ECharts v5
   - Feat: support echart theme object
   - Perf: resize animation
 
 - 2021.01.10: v6.0.1:
+
   - [PR #295](https://github.com/xieziyu/ngx-echarts/pull/295): Guard dispose (by [taipeiwu](https://github.com/taipeiwu))
 
 - 2021.01.10: v6.0.0:
@@ -333,7 +335,9 @@ It supports following event outputs:
 You can refer to the ECharts tutorial: [Events and Actions in ECharts](https://echarts.apache.org/en/tutorial.html#Events%20and%20Actions%20in%20ECharts) for more details of the event params. You can also refer to the [demo](https://xieziyu.github.io/#/ngx-echarts/demo) page for a detailed example.
 
 # Custom Build
+
 ## Legacy Custom Build
+
 > Please refer to [ECharts Documentation](https://echarts.apache.org/en/tutorial.html#Create%20Custom%20Build%20of%20ECharts) for more details.
 
 If you want to produce a custom build of ECharts, prepare a file like `custom-echarts.ts`:
@@ -389,10 +393,13 @@ function (root, factory) {
     }
 }
 ```
+
 ## Treeshaking Custom Build
+
 > Since version 5.0.1 ECharts supports [Treeshaking with NPM](https://echarts.apache.org/en/tutorial.html#Use%20ECharts%20with%20bundler%20and%20NPM).
 
 There is no need for the `custom-echarts.ts` file anymore. The `app.modules.ts` should look like this:
+
 ```typescript
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
@@ -405,38 +412,48 @@ import { AppComponent } from './app.component';
 // Import the echarts core module, which provides the necessary interfaces for using echarts.
 import * as echarts from 'echarts/core';
 // Import bar charts, all with Chart suffix
-import {
-    BarChart
-} from 'echarts/charts';
-import {
-  TitleComponent,
-  TooltipComponent,
-  GridComponent
-} from 'echarts/components';
+import { BarChart } from 'echarts/charts';
+import { TitleComponent, TooltipComponent, GridComponent } from 'echarts/components';
 // Import the Canvas renderer, note that introducing the CanvasRenderer or SVGRenderer is a required step
-import {
-  CanvasRenderer
-} from 'echarts/renderers';
+import { CanvasRenderer } from 'echarts/renderers';
 import 'echarts/theme/macarons.js';
 
-echarts.use(
-  [TitleComponent, TooltipComponent, GridComponent, BarChart, CanvasRenderer]
-);
+echarts.use([TitleComponent, TooltipComponent, GridComponent, BarChart, CanvasRenderer]);
 
 @NgModule({
-  declarations: [
-    AppComponent
-  ],
-  imports: [
-    BrowserModule,
-    NgxEchartsModule.forRoot({ echarts }),
-    HttpClientModule
-  ],
+  declarations: [AppComponent],
+  imports: [BrowserModule, NgxEchartsModule.forRoot({ echarts }), HttpClientModule],
+  providers: [],
+  bootstrap: [AppComponent],
+})
+export class AppModule {}
+```
+
+# Custom Locale
+
+You can change the chart locale registering a built-in locale (located in `node_modules/echarts/lib/i18n/`) or a custom locale object. To register a locale, you will need to change the module that echart is being imported (usually `app.module.ts`).
+
+```ts
+import {NgxEchartsModule} from "ngx-echarts";
+import * as echarts from 'echarts/core';
+import langCZ from 'echarts/lib/i18n/langCZ';
+
+echarts.registerLocale("CZ", langCZ)
+
+@NgModule({
+  imports: [NgxEchartsModule.forRoot({echarts})],
+  declarations: [],
   providers: [],
   bootstrap: [AppComponent]
 })
-export class AppModule { }
 ```
+
+and in your HTML file use:
+
+```html
+<div echarts [initOpts]="{ locale: 'CZ' }" [options]="options" class="demo-chart"></div>
+```
+
 # Demo
 
 You can clone this repo to your working copy and then launch the demo page in your local machine:

--- a/projects/ngx-echarts/src/lib/ngx-echarts.directive.ts
+++ b/projects/ngx-echarts/src/lib/ngx-echarts.directive.ts
@@ -40,6 +40,7 @@ export class NgxEchartsDirective implements OnChanges, OnDestroy, OnInit, AfterV
     renderer?: string;
     width?: number | string;
     height?: number | string;
+    locale?: string;
   };
   @Input() merge: EChartsOption;
   @Input() autoResize = true;
@@ -148,7 +149,7 @@ export class NgxEchartsDirective implements OnChanges, OnDestroy, OnInit, AfterV
     if (this.chart) {
       this.ngZone.runOutsideAngular(() => {
         this.chart.resize();
-      })
+      });
     }
   }
 


### PR DESCRIPTION
你好 Ziyu Xie，

I was facing some problems do change my graphs locale and I tried to follow the instructions provided in https://github.com/xieziyu/ngx-echarts/issues/290, but I had no success to change the locale. So in a further [investigation](https://jsfiddle.net/ydac567f/) with echarts package I found that is needed to register the built-in or custom location object and also change the chart locale option.

So to achieve this I added to `initOpts` the `locale` property and add a change locale section in README.

谢谢!