### PR TITLE
fix: missing NgxEchartsModule.forChild return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ A starter project on Github: https://github.com/xieziyu/ngx-echarts-starter
 
 # Latest Update
 
+- 2021.12.07: v8.0.1:
+  
+  - Fix: NgxEchartsModule.forChild() issue [#334](https://github.com/xieziyu/ngx-echarts/issues/334)
+
 - 2021.11.08: v8.0.0 / v7.1.0:
   
   - Fix: remove @juggle/resize-observer from the peer dependencies

--- a/projects/ngx-echarts/package.json
+++ b/projects/ngx-echarts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-echarts",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "author": "Xie, Ziyu",
   "license": "MIT",
   "keywords": [

--- a/projects/ngx-echarts/src/lib/ngx-echarts.module.ts
+++ b/projects/ngx-echarts/src/lib/ngx-echarts.module.ts
@@ -13,7 +13,7 @@ export class NgxEchartsModule {
       providers: [{ provide: NGX_ECHARTS_CONFIG, useValue: config }],
     };
   }
-  static forChild() {
+  static forChild(): ModuleWithProviders<NgxEchartsModule> {
     return {
       ngModule: NgxEchartsModule,
     };


### PR DESCRIPTION
fix: #334 