### PR TITLE
Use echarts types

### DIFF
--- a/projects/ngx-echarts/src/lib/ngx-echarts.directive.ts
+++ b/projects/ngx-echarts/src/lib/ngx-echarts.directive.ts
@@ -16,15 +16,22 @@ import {
 import { Observable, Subject, Subscription, asyncScheduler } from 'rxjs';
 import { switchMap, throttleTime } from 'rxjs/operators';
 import { ChangeFilter } from './change-filter';
-import type { EChartsOption, ECharts } from 'echarts';
+import type { EChartsOption, ECharts, init, registerTheme } from 'echarts';
 
 export interface NgxEchartsConfig {
   echarts: any | (() => Promise<any>);
 }
 
-export type ThemeOption = Record<string, any>;
-
 export const NGX_ECHARTS_CONFIG = new InjectionToken<NgxEchartsConfig>('NGX_ECHARTS_CONFIG');
+
+// 'echarts' library does not export the type 'EchartsInitOpts',
+// hence we extract it from the signature of 'echarts.init'.
+export type EChartsInitOpts = Parameters<typeof init>[2];
+
+// 'echarts' library does not export the type 'ThemeOption',
+// hence we extract it from the signature of 'registerTheme'.
+export type ThemeOption = Parameters<typeof registerTheme>[1];
+
 
 @Directive({
   selector: 'echarts, [echarts]',
@@ -34,13 +41,7 @@ export class NgxEchartsDirective implements OnChanges, OnDestroy, OnInit, AfterV
   @Input() options: EChartsOption;
   @Input() theme: string | ThemeOption;
   @Input() loading: boolean;
-  @Input() initOpts: {
-    devicePixelRatio?: number;
-    renderer?: string;
-    width?: number | string;
-    height?: number | string;
-    locale?: string;
-  };
+  @Input() initOpts: EChartsInitOpts;
   @Input() merge: EChartsOption;
   @Input() autoResize = true;
   @Input() loadingType = 'default';


### PR DESCRIPTION
Hello,
I have been using this library recently and I noticed that two type definitions are no longer in sync with echarts library definitions (I am compiling my project with typescript strict type checking enabled).
Please review my changes and merge them if they are fine.

Note that `EChartsInitOpts` could also be extracted with something like:
```ts
    import { ECharts } from 'echarts';
    type EChartsInitOpts = ConstructorParameters<ECharts>[2]; 
```
However, this snippet raises an error that I have not been able to fix (something similar may also be done for `ThemeOption`).