### PR TITLE
feat: support default theme for all chart instances

### DIFF
--- a/projects/ngx-echarts/src/lib/ngx-echarts.directive.ts
+++ b/projects/ngx-echarts/src/lib/ngx-echarts.directive.ts
@@ -111,9 +111,7 @@ export class NgxEchartsDirective implements OnChanges, OnDestroy, OnInit, AfterV
     private ngZone: NgZone
   ) {
     this.echarts = config.echarts;
-    if (!this.theme && config.theme) {
-      this.theme = config.theme;
-    }
+    this.theme = config.theme || null;
   }
 
   ngOnChanges(changes: SimpleChanges) {

--- a/projects/ngx-echarts/src/lib/ngx-echarts.directive.ts
+++ b/projects/ngx-echarts/src/lib/ngx-echarts.directive.ts
@@ -20,6 +20,7 @@ import type { EChartsOption, ECharts, ECElementEvent } from 'echarts';
 
 export interface NgxEchartsConfig {
   echarts: any | (() => Promise<any>);
+  theme?: string | ThemeOption;
 }
 
 export type ThemeOption = Record<string, any>;
@@ -110,6 +111,9 @@ export class NgxEchartsDirective implements OnChanges, OnDestroy, OnInit, AfterV
     private ngZone: NgZone
   ) {
     this.echarts = config.echarts;
+    if (!this.theme && config.theme) {
+      this.theme = config.theme;
+    }
   }
 
   ngOnChanges(changes: SimpleChanges) {

--- a/projects/ngx-echarts/src/lib/ngx-echarts.module.ts
+++ b/projects/ngx-echarts/src/lib/ngx-echarts.module.ts
@@ -6,7 +6,7 @@ import {
   ThemeOption,
 } from './ngx-echarts.directive';
 
-const provideEcharts = (config?: Omit<NgxEchartsConfig, 'echarts'> = {}): Provider => {
+const provideEcharts = (config: Omit<NgxEchartsConfig, 'echarts'> = {}): Provider => {
   return {
     provide: NGX_ECHARTS_CONFIG,
     useFactory: () => ({

--- a/projects/ngx-echarts/src/lib/ngx-echarts.module.ts
+++ b/projects/ngx-echarts/src/lib/ngx-echarts.module.ts
@@ -6,10 +6,13 @@ import {
   ThemeOption,
 } from './ngx-echarts.directive';
 
-const provideEcharts = (): Provider => {
+const provideEcharts = (config?: Omit<NgxEchartsConfig, 'echarts'> = {}): Provider => {
   return {
     provide: NGX_ECHARTS_CONFIG,
-    useFactory: () => ({ echarts: () => import('echarts') }),
+    useFactory: () => ({
+      ...config,
+      echarts: () => import('echarts'),
+    }),
   };
 };
 


### PR DESCRIPTION
Add `theme` in `NgxEchartsConfig`. Can use `provideEcharts({ theme: 'your-theme' })` or `provideEchartsCore({ echarts, theme: 'your-theme' })` to specify the default theme, when using ngx-echarts but leave `[theme]` empty, echarts will get theme from config.