### PR TITLE
feat: add chartInit EventEmitter type

### DIFF
--- a/projects/ngx-echarts/src/lib/ngx-echarts.directive.ts
+++ b/projects/ngx-echarts/src/lib/ngx-echarts.directive.ts
@@ -49,7 +49,7 @@ export class NgxEchartsDirective implements OnChanges, OnDestroy, OnInit, AfterV
   @Input() loadingOpts: object | null = null;
 
   // ngx-echarts events
-  @Output() chartInit = new EventEmitter<any>();
+  @Output() chartInit = new EventEmitter<ECharts>();
   @Output() optionsError = new EventEmitter<Error>();
 
   // echarts mouse events


### PR DESCRIPTION
It was hard for me to find out, which type of object is emitted by the `chartInit` event emitter. So I think it would be a better dev experience to set it explicit to `ECharts` instead of  `any`.